### PR TITLE
Fixed setParam method and added test

### DIFF
--- a/parser.php
+++ b/parser.php
@@ -144,9 +144,10 @@ class Parser {
 		
 		if(empty($this->params[$param])) {
 			$this->params[$param] = $value;
-		} else {
-			$arr = array($this->params[$param], $value);
-			$this->params[$param] = $arr;
+		}elseif(is_array($this->params[$param])){
+		        $this->params[$param] = array_merge($this->params[$param], array($value));
+		}elseif(is_string($this->params[$param])){
+		        $this->params[$param] = array($this->params[$param],$value);
 		}
 		return true;
 	}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1,0 +1,101 @@
+<?php
+
+class ParserTest extends PHPUnit_Framework_TestCase {
+
+  public function testMultipleParamsReturnedInFlatArray(){
+
+    $docComments = ['/**
+        * Set a parameter
+        *
+        * @return bool True = the parameter has been set, false = the parameter was invalid
+        */',
+                    '/**
+        * Set a parameter
+        *
+        * @param string $param The parameter name to store
+        * @param string $value The value to set
+        * @param string $dummyOne a dummy value to test
+        * @return bool True = the parameter has been set, false = the parameter was invalid
+        */',
+                    '/**
+        * Set a parameter
+        *
+        * @param string $param The parameter name to store
+        * @param string $value The value to set
+        * @return bool True = the parameter has been set, false = the parameter was invalid
+        */',
+                    '/**
+        * Set a parameter
+        *
+        * @param string $param The parameter name to store
+        * @return bool True = the parameter has been set, false = the parameter was invalid
+        */'];
+
+    $output = [["access"=>'',
+                "author"=>'',
+                "copyright" =>'',
+                "deprecated"=>'',
+                "example"=>'',
+                "ignore"=>'',
+                "internal"=>'',
+                "link"=>'',
+                "param"=>'',
+                "return"=>'(bool)True = the parameter has been set, false = the parameter was invalid',
+                "see"=>'',
+                "since"=>'',
+                "tutorial"=>'',
+                "version"=> ''],
+               ["access"=>'',
+                "author"=>'',
+                "copyright" =>'',
+                "deprecated"=>'',
+                "example"=>'',
+                "ignore"=>'',
+                "internal"=>'',
+                "link"=>'',
+                "param"=>['(string)$param The parameter name to store',
+                          '(string)$value The value to set',
+                          '(string)$dummyOne a dummy value to test'],
+                "return"=>'(bool)True = the parameter has been set, false = the parameter was invalid',
+                "see"=>'',
+                "since"=>'',
+                "tutorial"=>'',
+                "version"=> ''],
+               ["access"=>'',
+                "author"=>'',
+                "copyright" =>'',
+                "deprecated"=>'',
+                "example"=>'',
+                "ignore"=>'',
+                "internal"=>'',
+                "link"=>'',
+                "param"=>['(string)$param The parameter name to store',
+                          '(string)$value The value to set'],
+                "return"=>'(bool)True = the parameter has been set, false = the parameter was invalid',
+                "see"=>'',
+                "since"=>'',
+                "tutorial"=>'',
+                "version"=> ''],
+               ["access"=>'',
+                "author"=>'',
+                "copyright" =>'',
+                "deprecated"=>'',
+                "example"=>'',
+                "ignore"=>'',
+                "internal"=>'',
+                "link"=>'',
+                "param"=>'(string)$param The parameter name to store',
+                "return"=>'(bool)True = the parameter has been set, false = the parameter was invalid',
+                "see"=>'',
+                "since"=>'',
+                "tutorial"=>'',
+                "version"=> '']];
+
+    for($i = 0; $i<count($docComments); $i++){
+      $parser = new parser($docComments[$i]);
+      $parser->parse();
+      $this->assertEquals($output[$i],$parser->getParams());
+    }
+  }
+
+}


### PR DESCRIPTION
The set param method was storing params in a multidimensional array.  When you document more than two params the last param showed in the docs along with one empty param.  I've changed this method to store the params in a flat array so that all show up in the docs.  There's a test included also.
